### PR TITLE
JSON and str match

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -708,6 +708,9 @@ Interpreter.prototype.initString = function(scope) {
     var str = this.toString();
     regexp = regexp ? regexp.data : undefined;
     var match = str.match(regexp);
+    if (match === null) {
+      return thisInterpreter.createPrimitive(null);
+    }
     var pseudoList = thisInterpreter.createObject(thisInterpreter.ARRAY);
     for (var i = 0; i < match.length; i++) {
       thisInterpreter.setProperty(pseudoList, i,

--- a/interpreter.js
+++ b/interpreter.js
@@ -702,6 +702,20 @@ Interpreter.prototype.initString = function(scope) {
   };
   this.setProperty(this.STRING.properties.prototype, 'slice',
                    this.createNativeFunction(wrapper), false, true);
+
+  wrapper = function(regexp) {
+    var str = this.toString();
+    regexp = regexp ? regexp.data : undefined;
+    var match = str.match(regexp);
+    var pseudoList = thisInterpreter.createObject(thisInterpreter.ARRAY);
+    for (var i = 0; i < match.length; i++) {
+      thisInterpreter.setProperty(pseudoList, i,
+          thisInterpreter.createPrimitive(match[i]));
+    }
+    return pseudoList;
+  };
+  this.setProperty(this.STRING.properties.prototype, 'match',
+                   this.createNativeFunction(wrapper), false, true);
 };
 
 /**


### PR DESCRIPTION
###### Support for `JSON.parse`, `JSON.stringify` and `str.match(/..$/)`.

One thing, while testing `match` I found something weird: if I run `alert('abc'.match(/\w+/g))` in the example page, it works ok, but if I go to the console and type:
```javascript
var myInterpreter = new Interpreter("abc'.match(/\w+/g)")
myInterpreter.run()
alert(myInterpreter.value)
```
the alert shows `null`. Am I doing anything wrong? I noticed that the backslash (\\) from `\w` gets removed in acorn's generated ast.