### PR TITLE
string comparison fix

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -1675,7 +1675,11 @@ Interpreter.prototype['stepBinaryExpression'] = function() {
     var value;
     var comp = this.comp(leftSide, rightSide);
     if (node.operator == '==' || node.operator == '!=') {
-      value = comp === 0;
+      if (leftSide.isPrimitive && rightSide.isPrimitive)
+        value = leftSide.data == rightSide.data;
+      else
+        value = comp === 0;
+        
       if (node.operator == '!=') {
         value = !value;
       }
@@ -2281,7 +2285,10 @@ Interpreter.prototype['stepUnaryExpression'] = function() {
     } else if (node.operator == '+') {
       value = state.value.toNumber();
     } else if (node.operator == '!') {
-      value = !state.value.toNumber();
+      if (state.value.isPrimitive)
+        value = !state.value.data;
+      else
+        value = !state.value.toNumber();
     } else if (node.operator == '~') {
       value = ~state.value.toNumber();
     } else if (node.operator == 'typeof') {


### PR DESCRIPTION
When comparing strings with null, the results are wrong.
Example:
"test" == null returns true
!"test" returns true