### PR TITLE
continue interpreter when asyncFunc calls back

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -1861,10 +1861,11 @@ Interpreter.prototype['stepCallExpression'] = function() {
                                                    state.arguments);
       } else if (state.func_.asyncFunc) {
         var thisInterpreter = this;
-        var callback = function(value) {
+        var callback = function(value, resume) {
           state.value = value || this.UNDEFINED;
           thisInterpreter.stateStack.unshift(state)
           thisInterpreter.paused_ = false;
+          if (resume) thisInterpreter.run();
         };
         var argsWithCallback = state.arguments.concat(callback);
         state.func_.asyncFunc.apply(state.funcThis_, argsWithCallback);


### PR DESCRIPTION
I added a parameter so it doesn't automatically run, but only if you pass true after the value. I would recommend defaulting this to true.