### PR TITLE
Fix broken try statement searching logic

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -2408,7 +2408,7 @@ Interpreter.prototype.executeException = function(error) {
       state.throwValue = error;
       return;
     }
-  } while (state || state.node.type == 'Program');
+  } while (state && state.node.type != 'Program');
 
   // Throw a real error.
   var realError;


### PR DESCRIPTION
@NeilFraser Thank you for your great interpreter! I have learned a lot from your code.

Current implementation breaks when an error is thrown up to the root 'Program' node.

For example, 

```javascript
var myInterpreter = new Interpreter('throw new Error("something wrong")');
myInterpreter.run()
```

is expected to throw native `Error("something wrong")` object, but actually throws `TypeError: Cannot read property 'node' of undefined` object.

This PR fixes this bug by correctly checking root 'Program' node while searching for try statements.
