### PR TITLE
Fix regression in 'this' & 'try' step methods

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -3578,6 +3578,7 @@ Interpreter.prototype['stepSwitchStatement'] = function() {
 };
 
 Interpreter.prototype['stepThisExpression'] = function() {
+  var stack = this.stateStack;
   stack.pop();
   for (var i = stack.length - 1; i >= 0; i--) {
     if (stack[i].thisExpression) {
@@ -3601,6 +3602,7 @@ Interpreter.prototype['stepThrowStatement'] = function() {
 };
 
 Interpreter.prototype['stepTryStatement'] = function() {
+  var stack = this.stateStack;
   var state = stack[stack.length - 1];
   var node = state.node;
   if (!state.doneBlock_) {


### PR DESCRIPTION
Last commit was missing `var stack = this.stateStack` in a couple
places, causing use of 'this' and 'try' to fail.