### PR TITLE
Fixes for some hangs and crashes

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -1632,8 +1632,8 @@ Interpreter.prototype.isa = function(child, constructor) {
   if (!child || !constructor) {
     return false;
   }
-  while (child.properties.constructor != constructor) {
-    if (!child.properties.constructor || !child.proto) {
+  while (!child.properties || child.properties.constructor != constructor) {
+    if (!child.proto) {
       return false;
     }
     child = child.proto;

--- a/interpreter.js
+++ b/interpreter.js
@@ -2861,7 +2861,12 @@ Interpreter.prototype['stepBinaryExpression'] = function() {
         rightSide.isPrimitive ? rightSide.data : rightSide.toString();
     value = leftValue + rightValue;
   } else if (node.operator == 'in') {
-    value = this.hasProperty(rightSide, leftSide);
+    if (rightSide.isPrimitive) {
+      this.throwException(this.TYPE_ERROR,
+          'Expecting an object evaluating \'in\'');
+    } else {
+      value = this.hasProperty(rightSide, leftSide);
+    }
   } else if (node.operator == 'instanceof') {
     if (!this.isa(rightSide, this.FUNCTION)) {
       this.throwException(this.TYPE_ERROR,

--- a/interpreter.js
+++ b/interpreter.js
@@ -1552,7 +1552,13 @@ Interpreter.prototype.initJSON = function(scope) {
 
   wrapper = function(value) {
     var nativeObj = thisInterpreter.pseudoToNative(value);
-    return thisInterpreter.createPrimitive(JSON.stringify(nativeObj));
+    try {
+      var str = JSON.stringify(nativeObj);
+    } catch (e) {
+      thisInterpreter.throwException(thisInterpreter.TYPE_ERROR, e.message);
+      return;
+    }
+    return thisInterpreter.createPrimitive(str);
   };
   this.setProperty(myJSON, 'stringify',
       this.createNativeFunction(wrapper, false));

--- a/interpreter.js
+++ b/interpreter.js
@@ -3578,6 +3578,7 @@ Interpreter.prototype['stepSwitchStatement'] = function() {
 };
 
 Interpreter.prototype['stepThisExpression'] = function() {
+  var stack = this.stateStack;
   stack.pop();
   for (var i = stack.length - 1; i >= 0; i--) {
     if (stack[i].thisExpression) {
@@ -3601,6 +3602,7 @@ Interpreter.prototype['stepThrowStatement'] = function() {
 };
 
 Interpreter.prototype['stepTryStatement'] = function() {
+  var stack = this.stateStack;
   var state = stack[stack.length - 1];
   var node = state.node;
   if (!state.doneBlock_) {


### PR DESCRIPTION
A few quick fixes of problems I noticed:
* on top of regression fix https://github.com/NeilFraser/JS-Interpreter/pull/105
* fix properties on strings
* fix pseudoToNative and JSON.stringify to not try to export non-enumerable constructor property
* fix pseudoToNative to handle object cycles without crashing
* fix JSON.stringify throw a catchable error on cycles
* fix Array join & toString to handle cycles (not specced, but browsers do it this way)
* fix 'in' operator to throw a catchable error if given a primitive