### PR TITLE
Fix setter that does not work correctly when assigned value is falsy

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -2630,7 +2630,7 @@ Interpreter.prototype['stepAssignmentExpression'] =
     // Setter method on property has completed.
     // Ignore its return value, and use the original set value instead.
     stack.pop();
-    stack[stack.length - 1].value = state.doneSetter_;
+    stack[stack.length - 1].value = state.setterValue_;
     return;
   }
   var value = state.leftValue_;
@@ -2653,7 +2653,8 @@ Interpreter.prototype['stepAssignmentExpression'] =
   }
   var setter = this.setValue(state.leftReference_, value);
   if (setter) {
-    state.doneSetter_ = value;
+    state.doneSetter_ = true;
+    state.setterValue_ = value;
     return this.createSetter_(setter, state.leftReference_, value);
   }
   // Return if no setter function.
@@ -3487,7 +3488,7 @@ Interpreter.prototype['stepUpdateExpression'] = function(stack, state, node) {
     // Setter method on property has completed.
     // Ignore its return value, and use the original set value instead.
     stack.pop();
-    stack[stack.length - 1].value = state.doneSetter_;
+    stack[stack.length - 1].value = state.setterValue_;
     return;
   }
   var leftValue = Number(state.leftValue_);
@@ -3502,7 +3503,8 @@ Interpreter.prototype['stepUpdateExpression'] = function(stack, state, node) {
   var returnValue = node['prefix'] ? changeValue : leftValue;
   var setter = this.setValue(state.leftSide_, changeValue);
   if (setter) {
-    state.doneSetter_ = returnValue;
+    state.doneSetter_ = true;
+    state.setterValue_ = returnValue;
     return this.createSetter_(setter, state.leftSide_, changeValue);
   }
   // Return if no setter function.


### PR DESCRIPTION
minimal code to reproduce

```javascript
const interpreter = new Interpreter('a.b = false', (interpreter, scope) => {
  const obj = interpreter.createObjectProto(interpreter.OBJECT_PROTO);

  interpreter.setProperty(scope, 'a', obj);
  interpreter.setProperty(obj, 'b', Interpreter.VALUE_IN_DESCRIPTOR, {
    set: interpreter.createNativeFunction(console.log)
  });
});

interpreter.run(); // infinite loop
```

Since the value assigned to setter is [used](https://github.com/NeilFraser/JS-Interpreter/blob/1301ea9cfce6fa33931bbe829938117cdb28f0ee/interpreter.js#L2656) to [detect whether setter execution is complete or not](https://github.com/NeilFraser/JS-Interpreter/blob/1301ea9cfce6fa33931bbe829938117cdb28f0ee/interpreter.js#L2628), if it is falsy, the stack will not pop and will go into an infinite loop.
