### PR TITLE
support npm with github 

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -3944,3 +3944,7 @@ Interpreter.prototype['nativeToPseudo'] = Interpreter.prototype.nativeToPseudo;
 Interpreter.prototype['pseudoToNative'] = Interpreter.prototype.pseudoToNative;
 // Obsolete.  Do not use.
 Interpreter.prototype['createPrimitive'] = function(x) {return x;};
+
+if (typeof exports === 'object' && typeof module === 'object') {
+  module.exports = Interpreter;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "js-interpreter",
+  "private": true,
+  "version": "0.0.1",
+  "description": "A sandboxed JavaScript interpreter in JavaScript.  Execute arbitrary JavaScript code line by line in isolation and safety.",
+  "main": "interpreter.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NeilFraser/JS-Interpreter.git"
+  },
+  "author": "Neil Fraser",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/NeilFraser/JS-Interpreter/issues"
+  },
+  "homepage": "https://github.com/NeilFraser/JS-Interpreter#readme"
+}


### PR DESCRIPTION
so that users can

```
npm install --save github:NeilFraser/JS-Interpreter
```

closes #156

See https://docs.npmjs.com/cli/install

I wondered if it would work without `name` but it's required. It's a bit misleading if someone else owns `js-interpreter` on npm. Ideally you would register a new name and use that to prevent any confusion.
