### PR TITLE
Remove unneeded error class

### DIFF
--- a/interpreter.js
+++ b/interpreter.js
@@ -1950,7 +1950,7 @@ Interpreter.Object.prototype.toString = function() {
     }
     return strs.join(',');
   }
-  if (this.class === 'Error') {
+  if (this.isa(obj, this.ERROR)) {
     var cycles = Interpreter.toStringCycles_;
     if (cycles.indexOf(this) !== -1) {
       return '[object Error]';
@@ -2025,11 +2025,7 @@ Interpreter.prototype.createObjectProto = function(proto) {
   if (typeof proto !== 'object') {
     throw Error('Non object prototype');
   }
-  var obj = new Interpreter.Object(proto);
-  if (this.isa(obj, this.ERROR)) {
-    obj.class = 'Error';
-  }
-  return obj;
+  return new Interpreter.Object(proto);
 };
 
 /**


### PR DESCRIPTION
Chris, can you think of any reason why the 'Error' `.class` is needed in JS-Interpreter?  We use `.class` for Array and Function, since one can build children of each that are not real arrays or functions.  But I don't see the point of 'Error'.