### PR TITLE
Fallback to globalThis in acorn.js if this is not available

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -30,7 +30,7 @@
   if (typeof exports === "object" && typeof module === "object") return mod(exports); // CommonJS
   if (typeof define === "function" && define.amd) return define(["exports"], mod); // AMD
   mod(root.acorn || (root.acorn = {})); // Plain browser env
-})(this, function(exports) {
+})(this || globalThis, function(exports) {
   "use strict";
 
   exports.version = "0.5.0";


### PR DESCRIPTION
This increases compatibility of the included `acorn.js` file to support environments that don't support a root `this` object (e.g., Deno) by falling back to `globalThis` if `this` is not defined.

When using the base `JS-Interpreter` with Deno, the following error happens:

```
error: TypeError: Cannot read properties of undefined (reading 'acorn')
  mod(root.acorn || (root.acorn = {})); // Plain browser env
           ^
    at https://raw.githubusercontent.com/NeilFraser/JS-Interpreter/10a8cf5e613834b5d36655c1921f818455fc324a/acorn.js:32:12
    at https://raw.githubusercontent.com/NeilFraser/JS-Interpreter/10a8cf5e613834b5d36655c1921f818455fc324a/acorn.js:33:3
```

This patch resolves the error.