### PR TITLE
js-interpreter including ESM and in the npm ecosystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ test262-es5-tests/
 
 test262.js
 /compiler.jar
+
+interpreter-esm.js
+acorn-esm.js

--- a/acorn.js
+++ b/acorn.js
@@ -26,14 +26,25 @@
 // [dammit]: acorn_loose.js
 // [walk]: util/walk.js
 
-(function(root, mod) {
-  if (typeof exports === "object" && typeof module === "object") return mod(exports); // CommonJS
-  if (typeof define === "function" && define.amd) return define(["exports"], mod); // AMD
-  mod(root.acorn || (root.acorn = {})); // Plain browser env
-})((typeof globalThis === 'undefined') ? this || window : globalThis, function(exports) {
+var parse
+var version
+
+(function (root, factory) {
+   if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
+      // CommonJS. The commonJS module will export 'parse' and 'version'
+      factory(exports);
+    } else if (typeof asEsm !== 'undefined'){
+      // ESM
+      factory({})
+  } else {
+      // Browser globals. In this case, only window.acorn will be set,
+      // which will contain 'parse' and 'version'
+      factory(root.acorn || (root.acorn = {}));
+  }
+}(typeof self !== 'undefined' ? self : this, function (exports) {
   "use strict";
 
-  exports.version = "0.5.0";
+  exports.version = version = "0.5.0";
   // Plus additional edits marked with 'JS-Interpreter change' comments.
 
   // JS-Interpreter change:
@@ -73,7 +84,7 @@
    * @param {Object=} opts
    * @returns
    */
-  exports.parse = function(inpt, opts) {
+  exports.parse = parse = function(inpt, opts) {
     input = String(inpt);
     inputLen = input.length;
     setOptions(opts);
@@ -2280,4 +2291,4 @@
     return finishNode(node, "Identifier");
   }
 
-});
+}))

--- a/createEsmFiles.js
+++ b/createEsmFiles.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+
+// File paths and content to add
+const filesToModify = [
+  { original: 'interpreter.js', new: 'interpreter-esm.js', insertionAnchor: 'var Interpreter', contentToAdd: "import { parse, version } from './acorn-esm.js';\nvar asEsm = true;\nexport { Interpreter, parse, version as acornVersion };\n\n" },
+  { original: 'acorn.js', new: 'acorn-esm.js', insertionAnchor: 'var version', contentToAdd: "export { parse, version };\nvar asEsm = true;\n\n" }
+];
+
+// Loop through each file to modify
+filesToModify.forEach(file => {
+  const originalContent = fs.readFileSync(file.original, 'utf8');
+  const insertionIndex = originalContent.indexOf(file.insertionAnchor);
+
+  if (insertionIndex !== -1) {
+    const insertionPoint = insertionIndex + file.insertionAnchor.length;
+    const newContent = originalContent.substring(0, insertionPoint) + '\n' +  // Add newline character
+                      file.contentToAdd +
+                      originalContent.substring(insertionPoint);
+
+    fs.writeFileSync(file.new, newContent);
+    console.log(`Modified ${file.original} and saved as ${file.new}`);
+  } else {
+    console.error(`Insertion anchor not found in ${file.original}`);
+  }
+});

--- a/index-esm.html
+++ b/index-esm.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>JS-Interpreter Demo</title>
+  <link href="demos/style.css" rel="stylesheet" type="text/css">
+
+  <script type="module">
+  
+    import { Interpreter, parse, acornVersion } from './interpreter-esm.js'
+
+    console.log('Acorn version:', acornVersion)
+    var myInterpreter;
+    function initAlert(interpreter, globalObject) {
+      var wrapper = function alert(text) {
+        return window.alert(arguments.length ? text : '');
+      };
+      interpreter.setProperty(globalObject, 'alert',
+          interpreter.createNativeFunction(wrapper));
+    }
+
+    function parseButton() {
+      var code = document.getElementById('code').value;
+      myInterpreter = new Interpreter(code, initAlert);
+      disable('');
+    }
+    window.parseButton = parseButton
+
+
+    function stepButton() {
+      var stack = myInterpreter.getStateStack();
+      if (stack.length) {
+        var node = stack[stack.length - 1].node;
+        var start = node.start;
+        var end = node.end;
+      } else {
+        var start = 0;
+        var end = 0;
+      }
+      createSelection(start, end);
+      try {
+        var ok = myInterpreter.step();
+      } finally {
+        if (!ok) {
+          disable('disabled');
+        }
+      }
+    }
+    window.stepButton = stepButton
+
+    function runButton() {
+      disable('disabled');
+      if (myInterpreter.run()) {
+        // Async function hit.  There's more code to run.
+        setTimeout(runButton, 100);
+      }
+    }
+    window.runButton = runButton
+
+    function disable(disabled) {
+      document.getElementById('stepButton').disabled = disabled;
+      document.getElementById('runButton').disabled = disabled;
+    }
+
+    function createSelection(start, end) {
+      var field = document.getElementById('code');
+      if (field.createTextRange) {
+        var selRange = field.createTextRange();
+        selRange.collapse(true);
+        selRange.moveStart('character', start);
+        selRange.moveEnd('character', end);
+        selRange.select();
+      } else if (field.setSelectionRange) {
+        field.setSelectionRange(start, end);
+      } else if (field.selectionStart) {
+        field.selectionStart = start;
+        field.selectionEnd = end;
+      }
+      field.focus();
+    }
+  </script>
+</head>
+<body>
+  <h1>JS-Interpreter Demo</h1>
+
+  <p>Enter JavaScript code below, then click <em>Parse</em>.  To execute, either
+  click <em>Step</em> repeatedly, or click <em>Run</em> once.
+  Open your browser's console for errors.</p>
+  <p><textarea id="code" spellcheck="false">
+var result = [];
+function fibonacci(n, output) {
+  var a = 1, b = 1, sum;
+  for (var i = 0; i &lt; n; i++) {
+    output.push(a);
+    sum = a + b;
+    a = b;
+    b = sum;
+  }
+}
+fibonacci(16, result);
+alert(result.join(', '));
+</textarea><br>
+  <button onclick="parseButton()">Parse</button>
+  <button onclick="stepButton()" id="stepButton" disabled="disabled">Step</button>
+  <button onclick="runButton()" id="runButton" disabled="disabled">Run</button>
+  </p>
+
+  <p>Read the <a href="docs.html">JS-Interpreter documentation</a>.</p>
+  <p>Get the <a href="https://github.com/NeilFraser/JS-Interpreter">source code</a>.</p>
+
+</body>
+</html>

--- a/interpreter.js
+++ b/interpreter.js
@@ -1573,8 +1573,9 @@ Interpreter.prototype.initString = function(globalObject) {
   var thisInterpreter = this;
   var wrapper;
   // String constructor.
+  var OriginalString = String
   wrapper = function String(value) {
-    value = arguments.length ? String(value) : '';
+    value = arguments.length ? OriginalString(value) : '';
     if (thisInterpreter.calledWithNew()) {
       // Called as `new String()`.
       this.data = value;
@@ -1819,8 +1820,9 @@ Interpreter.prototype.initBoolean = function(globalObject) {
   var thisInterpreter = this;
   var wrapper;
   // Boolean constructor.
+  var OriginalBoolean = Boolean
   wrapper = function Boolean(value) {
-    value = Boolean(value);
+    value = OriginalBoolean(value);
     if (thisInterpreter.calledWithNew()) {
       // Called as `new Boolean()`.
       this.data = value;
@@ -1843,8 +1845,9 @@ Interpreter.prototype.initNumber = function(globalObject) {
   var thisInterpreter = this;
   var wrapper;
   // Number constructor.
+  var OriginalNumber = Number
   wrapper = function Number(value) {
-    value = arguments.length ? Number(value) : 0;
+    value = arguments.length ? OriginalNumber(value) : 0;
     if (thisInterpreter.calledWithNew()) {
       // Called as `new Number()`.
       this.data = value;
@@ -1927,17 +1930,18 @@ Interpreter.prototype.initNumber = function(globalObject) {
 Interpreter.prototype.initDate = function(globalObject) {
   var thisInterpreter = this;
   var wrapper;
+  var OriginalDate = Date
   // Date constructor.
   wrapper = function Date(_value, var_args) {
     if (!thisInterpreter.calledWithNew()) {
       // Called as `Date()`.
       // Calling Date() as a function returns a string, no arguments are heeded.
-      return Date();
+      return OriginalDate();
     }
     // Called as `new Date(...)`.
     var args = [null].concat(Array.from(arguments));
     this.data = new (Function.prototype.bind.apply(
-        Date, args));
+        OriginalDate, args));
     return this;
   };
   this.DATE = this.createNativeFunction(wrapper, true);
@@ -2006,6 +2010,7 @@ Interpreter.prototype.initRegExp = function(globalObject) {
   var thisInterpreter = this;
   var wrapper;
   // RegExp constructor.
+  var OriginalRegExp = RegExp
   wrapper = function RegExp(pattern, flags) {
     if (thisInterpreter.calledWithNew()) {
       // Called as `new RegExp()`.
@@ -2027,7 +2032,7 @@ Interpreter.prototype.initRegExp = function(globalObject) {
           'Invalid regexp flag: ' + flags);
     }
     try {
-      var nativeRegExp = new RegExp(pattern, flags)
+      var nativeRegExp = new OriginalRegExp(pattern, flags)
     } catch (e) {
       // Throws if flags are repeated.
       thisInterpreter.throwException(thisInterpreter.SYNTAX_ERROR, e.message);

--- a/interpreter.js
+++ b/interpreter.js
@@ -12,14 +12,13 @@ var Interpreter
       //
       // A one-liner to test commonJS is to run node and feed this to it:
       // int = require('./interpreter.js');i = new int.Interpreter('a = new String(); 4+4;');i.run();i.value;
-      debugger
       var acorn  = require('./acorn.js')
       exports.parse = acorn.parse
       exports.acornVersion = acorn.version
       factory(exports);
   } else if (typeof asEsm !== 'undefined'){
       // ESM
-      // No need to define acorn, since it will be defined in an injected line
+      // No need to define `parse`, since it will be defined in an injected line
       factory({ parse, acornVersion: version })
   } else {  
       // Browser globals

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "js-interpreter-esm",
+  "version": "1.0.0",
+  "description": "Neil Fraser's official JS-Interpreter",
+  "main": "js-interpreter.js",
+  "module": "js-interpreter-esm.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "node createEsmFiles.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mobily-enterprises/JS-Interpreter-esm.git"
+  },
+  "keywords": [
+    "JS-Interpreter",
+    "acorn"
+  ],
+  "author": "Neil Fraser",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/mobily-enterprises/JS-Interpreter-esm/issues"
+  },
+  "homepage": "https://github.com/mobily-enterprises/JS-Interpreter-esm#readme"
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mobily-enterprises/JS-Interpreter-esm.git"
+    "url": "git+https://github.com/NeilFraser/JS-Interpreter.git"
   },
   "keywords": [
     "JS-Interpreter",
@@ -19,7 +19,7 @@
   "author": "Neil Fraser",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/mobily-enterprises/JS-Interpreter-esm/issues"
+    "url": "https://github.com/NeilFraser/JS-Interpreter/issues"
   },
-  "homepage": "https://github.com/mobily-enterprises/JS-Interpreter-esm#readme"
+  "homepage": "https://github.com/NeilFraser/JS-Interpreter#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-interpreter-esm",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Neil Fraser's official JS-Interpreter",
   "main": "interpreter.js",
   "module": "interpreter-esm.js",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "js-interpreter-esm",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Neil Fraser's official JS-Interpreter",
-  "main": "js-interpreter.js",
-  "module": "js-interpreter-esm.js",
+  "main": "interpreter.js",
+  "module": "interpreter-esm.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "node createEsmFiles.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-interpreter-esm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Neil Fraser's official JS-Interpreter",
   "main": "js-interpreter.js",
   "module": "js-interpreter-esm.js",


### PR DESCRIPTION
Alright, I did it. This is finally something I am actually proud of.
So, here are the changes in a nutshell:

# acorn.js

I changed the export code at the top so that it's a little neater, AND it's all ready for the possible tiny code injection at the top to turn this into an ESM. I got rid of AMD support (which would have made things way more difficult). 
I got rid of the `globalThis` pattern. It can be re-added, but... I am not 10000% sure what pattern that is; let me know if it's something that's really absolutely wanted.

(Please note that I am a big fan of keeping things simple and easy. I am sure there are plenty of magic tools out there that are able to turn the given file into a magic UMD. The tool you use depends on the current fashion; I've seen so many... Grunt, Gulp, Webpack, Rollup, Parcel... then the current fashion is Vite but then there is BUN... Sorry, I prefer 9 lines of code, especially now that we can FINALLY say that AMD is history. Hopefully, CJS and "browser globals" will also be history soon enough, and we will no longer need any building, etc. Till then, it's 9 lines of code...)

So, here is a summary of the changes:

# interpreter.js

I added the header to make it multi-format (commonJS, browser's global, and ESM if a tiny injection at the top is added).
It now uses a well established multi-format pattern. So, I got rid of the `Interpreter.nativeGlobal` variable which was based on `globalThis` etc. Another thing I did -- partially as a consequence of the nativeGlobal thing` was to change this:

````
    value = arguments.length ? Interpreter.nativeGlobal.String(value) : '';
````

Into this:

````
    value = arguments.length ? String(value) : '';
````
**EDIT:** No I didn't. I made this change, and then fixed it when I realised that the point is to use the original methods before redefining them. I did it but without using the now removed `nativeGlobal` -- see change to see**

The same for Boolean, Number, Date, etc.
I am still not sure what globalThis is about. I looked at the issues, and there is something about problems with using `import` on it (which I am AMAZED it would ever even work). But it looks like it's something that is addresses with this PR.

# createEsmFiles.js

This is a new file. It injects TINY amounts of code into interpreter.js and acorn.js so that they export the right variables. This building step is necessary.
The added code is very minimal.
This is added to `interpreter.js`:

```
import { parse, version } from './acorn-esm.js';
var asEsm = true;
export { Interpreter, parse, version as acornVersion };
```

And this is added to `acorn.js`:

````
export { parse, version };
var asEsm = true;
````

That's it! This will create `interpreter-esm.js` and `acorn-esm.js` as fully usable esm modules. Because the step is so tiny, I actually do this as a postinstall task in NPM.

This could potentially be a problem as people will only get those files after a `npm install`. If they clone it, they will need to run `generateEsmFiles.js` to generate them.

Alternatively, we can turn this into a `build` task, and remove the `-esm` files from `.gitignore`.

# index-esm.html

This is the same as index.html, but it loads the interpreter as an ESM module instead. It works exactly the same.

We need to decide what to do about the `acorn_interpreter.js` file. I am sure we need to keep it, or existing users that expect it will have a heart attack. I THINK the building process should work the exact same (or maybe THAT is the piece of the puzzle that needs `nativeGlobal`?!?).

I need to test this in a proper NPM project, to check that tools like `vite` load everything fine etc. But I don't anticipate huge problems there.

I hope this helps.


